### PR TITLE
[Fix] Solve typo issues in ppl2 libraries

### DIFF
--- a/ppl2/include/ppl_projection.hpp
+++ b/ppl2/include/ppl_projection.hpp
@@ -160,7 +160,7 @@ public:
     }
 
 
-#ifdef PLL_EXTERNAL_TRACK_LOADING
+#ifdef PPL_EXTERNAL_TRACK_LOADING
 
     uint64_t num_of_p(char *addr, const uint64_t& len){
 


### PR DESCRIPTION
There is a small typo when users would like to read data from files. The preprocessing condition will not be activated due to a typo in the name of the define PPL_EXTERNAL_TRACK_LOADING.